### PR TITLE
Replace C-style arrays by Java-style (plus minor cleanups)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ v2 doc rp
 
 will have the same sign (+1) or (-1) if they are both on the same side of rp.
 
-If we take LOTS of random vectors (rp1, rp2, rp3), and repeat this, for close vectors, we expect the sign to be the same more often. That is, the close vectors are much more often on teh same side than far apart vectors. So for close vectors v1 and v2, when we take dot products between rp1 rp2 and rp3, we get the resulting signs
+If we take LOTS of random vectors (rp1, rp2, rp3), and repeat this, for close vectors, we expect the sign to be the same more often. That is, the close vectors are much more often on the same side than far apart vectors. So for close vectors v1 and v2, when we take dot products between rp1 rp2 and rp3, we get the resulting signs
 
 |   |  rp1 | rp2  | rp3  |
 |---|------|------|------|

--- a/src/main/java/com/o19s/hangry/QueryBuilder.java
+++ b/src/main/java/com/o19s/hangry/QueryBuilder.java
@@ -1,7 +1,6 @@
 package com.o19s.hangry;
 
 import com.o19s.hangry.randproj.RandomProjectionTree;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
@@ -35,7 +34,7 @@ public class QueryBuilder {
         BooleanQuery.Builder bqb = new BooleanQuery.Builder();
 
         // collect every query token, turn into prefix query
-        List<BooleanClause> bcs = new ArrayList<BooleanClause>();
+        List<BooleanClause> bcs = new ArrayList<>();
         BooleanQuery bq = new BooleanQuery.Builder().build();
         TermToBytesRefAttribute termAtt = tokenizer.getAttribute(TermToBytesRefAttribute.class);
         while (tokenizer.incrementToken()) {

--- a/src/main/java/com/o19s/hangry/VectorTokenizer.java
+++ b/src/main/java/com/o19s/hangry/VectorTokenizer.java
@@ -3,7 +3,6 @@ package com.o19s.hangry;
 import com.o19s.hangry.randproj.RandomProjectionTree;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.TermToBytesRefAttribute;
 
 import java.io.IOException;
 

--- a/src/main/java/com/o19s/hangry/randproj/RandomProjectionTree.java
+++ b/src/main/java/com/o19s/hangry/randproj/RandomProjectionTree.java
@@ -28,9 +28,9 @@ public class RandomProjectionTree {
 
     public double similarity(double[] vect1, double[] vect2) {
         double same = 0;
-        for (int i = 0; i < _projections.length; i++) {
-            double dp1 = VectorUtils.dotProduct(vect1, _projections[i]);
-            double dp2 = VectorUtils.dotProduct(vect2, _projections[i]);
+        for (double[] projection : _projections) {
+            double dp1 = VectorUtils.dotProduct(vect1, projection);
+            double dp2 = VectorUtils.dotProduct(vect2, projection);
             same += sameSign(dp1, dp2);
 
         }

--- a/src/main/java/com/o19s/hangry/randproj/RandomVectorFactory.java
+++ b/src/main/java/com/o19s/hangry/randproj/RandomVectorFactory.java
@@ -2,5 +2,5 @@ package com.o19s.hangry.randproj;
 
 public interface RandomVectorFactory {
 
-    public double[] nextVector();
+    double[] nextVector();
 }

--- a/src/main/java/com/o19s/hangry/randproj/SeededRandomVectorFactory.java
+++ b/src/main/java/com/o19s/hangry/randproj/SeededRandomVectorFactory.java
@@ -1,10 +1,9 @@
 package com.o19s.hangry.randproj;
 
 import java.util.Random;
-import java.util.stream.DoubleStream;
 
 public class SeededRandomVectorFactory implements RandomVectorFactory {
-    // Random vectors regenareted (hopefully consistently!) from
+    // Random vectors regenerated (hopefully consistently!) from
     // an original seed. Good for testing & prototyping. Not sure
     // how I feel about this in prod with things like Java and the OS
     // being upgraded out from underneath us

--- a/src/main/java/com/o19s/hangry/randproj/VectorUtils.java
+++ b/src/main/java/com/o19s/hangry/randproj/VectorUtils.java
@@ -14,8 +14,8 @@ public class VectorUtils {
 
     public static double magnitude(double[] vect) {
         double sum = 0.0;
-        for (int i = 0; i < vect.length; i++) {
-            sum += vect[i] * vect[i];
+        for (double v : vect) {
+            sum += v * v;
         }
         return Math.sqrt(sum);
     }

--- a/src/test/java/com/o19s/hangry/RandomProjectionTreeTest.java
+++ b/src/test/java/com/o19s/hangry/RandomProjectionTreeTest.java
@@ -23,10 +23,10 @@ public class RandomProjectionTreeTest {
         RandomProjectionTree rp = new RandomProjectionTree(100, factory);
 
         // These are all really the same vector
-        double vect1[] = {0.001, 0.001, 0.001};
-        double vect2[] = {1.0, 1.0, 1.0};
+        double[] vect1 = {0.001, 0.001, 0.001};
+        double[] vect2 = {1.0, 1.0, 1.0};
 
-        double vect3[] = {0.002, 0.002, 0.002};
+        double[] vect3 = {0.002, 0.002, 0.002};
 
 
         double nearSim1 = rp.similarity(vect1, vect2);
@@ -38,8 +38,6 @@ public class RandomProjectionTreeTest {
         IndexWriterConfig config = new IndexWriterConfig(analyzer);
         Directory ramDir = new RAMDirectory();
         IndexWriter writer = new IndexWriter(ramDir, config);
-
-
     }
 
 
@@ -47,12 +45,12 @@ public class RandomProjectionTreeTest {
     public void testEncodedSimilarity() {
         RandomVectorFactory factory = new SeededRandomVectorFactory(0,2);
 
-        double vect1[] = {0.5,0.5};
-        double vect2[] = {0.4,0.5};
-        double vect3[] = {0.4,-0.5};
-        double vect4[] = {-0.4,-0.5};
+        double[] vect1 = {0.5,0.5};
+        double[] vect2 = {0.4,0.5};
+        double[] vect3 = {0.4,-0.5};
+        double[] vect4 = {-0.4,-0.5};
 
-        int identicals[] = new int[4];
+        int[] identicals = new int[4];
 
         for (int i = 0; i < 10; i++) {
             RandomProjectionTree rp = new RandomProjectionTree(10, factory);
@@ -86,16 +84,13 @@ public class RandomProjectionTreeTest {
         RandomVectorFactory factory = new SeededRandomVectorFactory(0,3);
         RandomProjectionTree rp = new RandomProjectionTree(100, factory);
 
-        double vect1[] = {-1.0, -1.0, -1.0};
-        double vect2[] = {1.0, 1.0, 1.0};
-        double vect3[] = {1.0, 1.0, 0.9};
-
+        double[] vect1 = {-1.0, -1.0, -1.0};
+        double[] vect2 = {1.0, 1.0, 1.0};
+        double[] vect3 = {1.0, 1.0, 0.9};
 
         double farSim = rp.similarity(vect1, vect2);
         double nearSim = rp.similarity(vect2, vect3);
 
         assertTrue(nearSim > farSim);
-
     }
-
 }

--- a/src/test/java/com/o19s/hangry/RandomVectoryFactoryTest.java
+++ b/src/test/java/com/o19s/hangry/RandomVectoryFactoryTest.java
@@ -12,25 +12,23 @@ public class RandomVectoryFactoryTest {
     @Test
     public void testGeneratesRand() {
         SeededRandomVectorFactory f = new SeededRandomVectorFactory((byte)12, (short)300);
-        double vect[] = f.nextVector();
+        double[] vect = f.nextVector();
         assertEquals(vect.length, 300);
         for (int i = 0; i < vect.length - 1; i++) {
             assertNotEquals(vect[i], vect[i+1]);
-
         }
-
     }
 
     @Test
     public void testDotProduct() {
-        double [] vect1 = {1.0, 1.0};
-        double [] vect2 = {2.5, -0.4};
+        double[] vect1 = {1.0, 1.0};
+        double[] vect2 = {2.5, -0.4};
 
         // Dot Product = 1*2.5 + 1*-0.4 = 2.5 + -0.4 = 2.1
         assertEquals(VectorUtils.dotProduct(vect1, vect2), 2.1, 0.01);
 
-        double [] vect3 = {12.95, -25.1};
-        double [] vect4 = {-2512, 100.5};
+        double[] vect3 = {12.95, -25.1};
+        double[] vect4 = {-2512, 100.5};
 
         // Dot Product = 12.95*-2512 + -25.1+100.5 = -35052.95
         assertEquals(VectorUtils.dotProduct(vect3, vect4), -35052.95, 0.01);
@@ -38,15 +36,15 @@ public class RandomVectoryFactoryTest {
 
     @Test(expected = ArrayIndexOutOfBoundsException.class)
     public void testDotProductThrows() {
-        double [] vect1 = {1.0, 1.0, 1.0};
-        double [] vect2 = {2.5, -0.4};
+        double[] vect1 = {1.0, 1.0, 1.0};
+        double[] vect2 = {2.5, -0.4};
         VectorUtils.dotProduct(vect1, vect2);
     }
 
     @Test
     public void testDotProductUpToVect1Len() {
-        double [] vect1 = {1.0, 1.0};
-        double [] vect2 = {2.5, -0.4, 0.5};
+        double[] vect1 = {1.0, 1.0};
+        double[] vect2 = {2.5, -0.4, 0.5};
 
         // Dot Product = 1*2.5 + 1*-0.4 = 2.5 + -0.4 = 2.1
         // 0.5 in vect2 is IGNORED
@@ -55,8 +53,8 @@ public class RandomVectoryFactoryTest {
 
     @Test
     public void testNormalize() {
-        double vect1[] = {0.001, 0.001, 0.001};
-        double vect2[] = {1.0, 1.0, 1.0};
+        double[] vect1 = {0.001, 0.001, 0.001};
+        double[] vect2 = {1.0, 1.0, 1.0};
 
         VectorUtils.normalize(vect1);
         VectorUtils.normalize(vect2);
@@ -66,8 +64,8 @@ public class RandomVectoryFactoryTest {
 
     @Test
     public void testEuclideanDistance() {
-        double vect1[] = {2.0, 3.0, 4.0};
-        double vect2[] = {1.0, 1.0, 1.0}; // (2-1)^2 + (3-1)^2 + (4-1)^2 = 1 + 4 + 9
+        double[] vect1 = {2.0, 3.0, 4.0};
+        double[] vect2 = {1.0, 1.0, 1.0}; // (2-1)^2 + (3-1)^2 + (4-1)^2 = 1 + 4 + 9
                                           // sqrt(1 + 4 + 9) = 3.7416
 
         double expectedEuclidDistance = 3.7416;
@@ -76,5 +74,4 @@ public class RandomVectoryFactoryTest {
         Assert.assertEquals(euclidDistance, expectedEuclidDistance,0.01);
 
     }
-
 }

--- a/src/test/java/com/o19s/hangry/VectorFieldTest.java
+++ b/src/test/java/com/o19s/hangry/VectorFieldTest.java
@@ -5,7 +5,6 @@ import com.o19s.hangry.helpers.LabeledVector;
 import com.o19s.hangry.randproj.RandomProjectionTree;
 import com.o19s.hangry.randproj.RandomVectorFactory;
 import com.o19s.hangry.randproj.SeededRandomVectorFactory;
-import com.o19s.hangry.randproj.SteppingVectorFactory;
 import com.o19s.hangry.randproj.VectorUtils;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -16,9 +15,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
@@ -26,13 +23,9 @@ import org.apache.lucene.store.RAMDirectory;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.awt.*;
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.Iterator;
-import java.util.PriorityQueue;
 import java.util.SortedSet;
-import java.util.TreeSet;
 
 import static junit.framework.TestCase.assertEquals;
 
@@ -66,13 +59,13 @@ public class VectorFieldTest {
 
         RandomVectorFactory factory = new SeededRandomVectorFactory(0,2);
 
-        RandomProjectionTree rp[] = new RandomProjectionTree[1];
+        RandomProjectionTree[] rp = new RandomProjectionTree[1];
         rp[0] = new RandomProjectionTree(5, factory);
 
         Document doc = new Document();
         doc.add(new StringField("id", "1234", Field.Store.YES));
 
-        double vect[] = {0.5,0.5};
+        double[] vect = {0.5,0.5};
         doc.add(new StringField("title", "test title", Field.Store.YES));
         doc.add(new TextField("vector", new VectorTokenizer(vect, rp)));
 
@@ -84,13 +77,13 @@ public class VectorFieldTest {
         QueryBuilder qb = new QueryBuilder(rp);
 
         // Test direct query for this, full depth of the tree, should exact match
-        double queryVect[] = {0.5,0.5};
+        double[] queryVect = {0.5,0.5};
         Query q = qb.buildQuery("vector", queryVect);
         TopDocs docs = searcher.search(q, 10);
         assertEquals(docs.totalHits.value, 1);
 
         // Test opposite query for this, full depth, should inexact match
-        double queryVect2[] = {-0.5,-0.5};
+        double[] queryVect2 = {-0.5,-0.5};
         Query q2 = qb.buildQuery("vector", queryVect2);
         TopDocs docs2 = searcher.search(q2, 10);
         assertEquals(docs2.totalHits.value, 0);
@@ -101,14 +94,14 @@ public class VectorFieldTest {
 
         RandomVectorFactory factory = new SeededRandomVectorFactory(0,2);
 
-        RandomProjectionTree rp[] = new RandomProjectionTree[1];
+        RandomProjectionTree[] rp = new RandomProjectionTree[1];
         rp[0] = new RandomProjectionTree(5, factory);
 
         IndexWriter iw = createIndex();
 
-        double vect1[] = {0.5,0.5};
-        double vect2[] = {0.4,0.5};
-        double vect3[] = {-0.4,0.5};
+        double[] vect1 = {0.5, 0.5};
+        double[] vect2 = {0.4, 0.5};
+        double[] vect3 = {-0.4,0.5};
 
         iw.addDocument(buildDoc("doc1", vect1, rp));
         iw.addDocument(buildDoc("doc2", vect2, rp));
@@ -118,7 +111,7 @@ public class VectorFieldTest {
         QueryBuilder qb = new QueryBuilder(rp);
 
         // Test direct query for this, full depth, should exact match
-        double queryVect[] = {0.5,0.5};
+        double[] queryVect = {0.5,0.5};
         Query q = qb.buildQuery("vector", queryVect, 2);
         IndexSearcher searcher = createSearcher(iw);
         TopDocs docs = searcher.search(q, 10);
@@ -131,17 +124,17 @@ public class VectorFieldTest {
         RandomVectorFactory factory = new SeededRandomVectorFactory(0,2);
 
         // Create 10 random projected vectors
-        RandomProjectionTree rp[] = new RandomProjectionTree[10];
+        RandomProjectionTree[] rp = new RandomProjectionTree[10];
         for (int i = 0; i < rp.length; i++) {
             rp[i] = new RandomProjectionTree(5, factory);
         }
 
         IndexWriter iw = createIndex();
 
-        double vect1[] = {0.5,0.5};
-        double vect2[] = {0.4,0.5};
-        double vect3[] = {0.4,-0.5};
-        double vect4[] = {-0.4,-0.5};
+        double[] vect1 = {0.5,0.5};
+        double[] vect2 = {0.4,0.5};
+        double[] vect3 = {0.4,-0.5};
+        double[] vect4 = {-0.4,-0.5};
 
         // Build 3 docs
         iw.addDocument(buildDoc("doc1", vect1, rp));
@@ -155,7 +148,7 @@ public class VectorFieldTest {
 
         // Depth 2 out of 5 (depth of trees) should give higher recall, but with
         // closer matches for nearby vectors, gradually farther away
-        double queryVect[] = {0.5,0.5};
+        double[] queryVect = {0.5,0.5};
         Query q = qb.buildQuery("vector", queryVect, 2);
         IndexSearcher searcher = createSearcher(iw);
         TopDocs docs = searcher.search(q, 10);
@@ -200,9 +193,7 @@ public class VectorFieldTest {
 
         }
 
-        for (int i = 0; i < vectors.length; i++) {
-            double[] vector = vectors[i];
-
+        for (double[] vector : vectors) {
             for (int dim = 0; dim < vector.length; dim++) {
                 if (vector[dim] > maxs[dim]) {
                     maxs[dim] = vector[dim];
@@ -243,7 +234,7 @@ public class VectorFieldTest {
 
         //RandomVectorFactory factory = new SteppingVectorFactory(0, DIMENSIONS, medians,mins,maxs);
 
-        RandomProjectionTree rp[] = new RandomProjectionTree[NUM_PROJ_TREES];
+        RandomProjectionTree[] rp = new RandomProjectionTree[NUM_PROJ_TREES];
         for (int i = 0; i < rp.length; i++) {
             rp[i] = new RandomProjectionTree(PROJ_TREE_DEPTH, seededFactory);
         }
@@ -302,7 +293,7 @@ public class VectorFieldTest {
         RandomVectorFactory factory = new SeededRandomVectorFactory(0, 300);
 
         // Create 10 random projected vectors
-        RandomProjectionTree rp[] = new RandomProjectionTree[100];
+        RandomProjectionTree[] rp = new RandomProjectionTree[100];
         for (int i = 0; i < rp.length; i++) {
             rp[i] = new RandomProjectionTree(5, factory);
         }
@@ -318,6 +309,4 @@ public class VectorFieldTest {
             indexMany(allVectors, 300, rp, iw);
         }
     }
-
-
 }

--- a/src/test/java/com/o19s/hangry/helpers/ExactNearestNeighbors.java
+++ b/src/test/java/com/o19s/hangry/helpers/ExactNearestNeighbors.java
@@ -27,7 +27,7 @@ public class ExactNearestNeighbors {
     }
 
     public static SortedSet<LabeledVector> nearestNeighbors(double[][] vectors, double[] queryVector) {
-        SortedSet<LabeledVector> sortedSet = new TreeSet<LabeledVector>(new LabeledVectorCompare(queryVector));
+        SortedSet<LabeledVector> sortedSet = new TreeSet<>(new LabeledVectorCompare(queryVector));
         for (int i = 0; i < vectors.length; i++) {
             boolean addedDoc = sortedSet.add(new LabeledVector(i, vectors[i]));
             assert(addedDoc);


### PR DESCRIPTION
This PR replaces c-style array declaration in tests by java-style ones, remove unused declaration (`long before = System.nanoTime();` on `VectorFieldTest.java`). 